### PR TITLE
remove handleClient delay for ESP32

### DIFF
--- a/src/ESP_WiFiManager_Lite.h
+++ b/src/ESP_WiFiManager_Lite.h
@@ -916,12 +916,6 @@ class ESP_WiFiManager_Lite
           if (server)
           {
             server->handleClient();
-
-            // Fix ESP32-S2 issue with WebServer (https://github.com/espressif/arduino-esp32/issues/4348)
-            if ( String(ARDUINO_BOARD) == "ESP32S2_DEV" )
-            {
-              delay(1);
-            }
           }
 
           return;


### PR DESCRIPTION
Fixed in [arduino-esp32](https://github.com/espressif/arduino-esp32) since Oct. 2020, see https://github.com/espressif/arduino-esp32/pull/4350.
No need to handle this in ESP_WiFiManager_Lite.